### PR TITLE
fix: handle missing foreign keys in ReferenceModel.__str__

### DIFF
--- a/openunderstand/gen/java8speedy/antlr4-runtime/include/support/guid.h
+++ b/openunderstand/gen/java8speedy/antlr4-runtime/include/support/guid.h
@@ -23,30 +23,42 @@
  */
 #pragma once
 
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <iomanip>
 #include <iostream>
-#include <vector>
 #include <sstream>
 #include <string>
-#include <iomanip>
-#include <stdint.h>
+#include <vector>
 
 #ifdef GUID_ANDROID
 #include <jni.h>
 #endif
 
+namespace antlrcpp {
+
 // Class to represent a GUID/UUID. Each instance acts as a wrapper around a
 // 16 byte value that can be passed around by value. It also supports
 // conversion to string (via the stream operator <<) and conversion from a
 // string via constructor.
-class Guid
-{
+class Guid final {
 public:
+  using size_type = typename std::array<uint8_t, 16>::size_type;
+  using pointer = typename std::array<uint8_t, 16>::pointer;
+  using const_pointer = typename std::array<uint8_t, 16>::const_pointer;
+  using iterator = typename std::array<uint8_t, 16>::iterator;
+  using reverse_iterator = typename std::array<uint8_t, 16>::reverse_iterator;
+  using const_iterator = typename std::array<uint8_t, 16>::const_iterator;
+  using const_reverse_iterator = typename std::array<uint8_t, 16>::const_reverse_iterator;
 
   // create a guid from vector of bytes
-  Guid(const std::vector<unsigned char> &bytes);
+  Guid(const std::vector<uint8_t> &bytes);
+
+  explicit Guid(const std::array<uint8_t, 16> &bytes);
 
   // create a guid from array of bytes
-  Guid(const unsigned char *bytes);
+  Guid(const uint8_t *bytes);
 
   // Create a guid from array of words.
   Guid(const uint16_t *bytes, bool reverse);
@@ -55,32 +67,61 @@ public:
   Guid(const std::string &fromString);
 
   // create empty guid
-  Guid();
+  Guid() = default;
 
   // copy constructor
-  Guid(const Guid &other);
+  Guid(const Guid &other) = default;
 
   // overload assignment operator
-  Guid &operator=(const Guid &other);
+  Guid &operator=(const Guid &other) = default;
 
   // overload equality and inequality operator
-  bool operator==(const Guid &other) const;
-  bool operator!=(const Guid &other) const;
+  friend bool operator==(const Guid &lhs, const Guid &rhs) {
+    return std::memcmp(lhs.data(), rhs.data(), 16) == 0;
+  }
 
-  const std::string toString() const;
-  std::vector<unsigned char>::const_iterator begin() { return _bytes.begin(); }
-  std::vector<unsigned char>::const_iterator end() { return _bytes.end(); }
-  std::vector<unsigned char>::const_reverse_iterator rbegin() { return _bytes.rbegin(); }
-  std::vector<unsigned char>::const_reverse_iterator rend() { return _bytes.rend(); }
+  friend bool operator!=(const Guid &lhs, const Guid &rhs) {
+    return !operator==(lhs, rhs);
+  }
 
+  // make the << operator a friend so it can access bytes_
+  friend std::ostream &operator<<(std::ostream &s, const Guid &guid);
+
+  pointer data() { return bytes_.data(); }
+
+  const_pointer data() const { return bytes_.data(); }
+
+  size_type size() const { return bytes_.size(); }
+
+  std::string toString() const;
+
+  iterator begin() { return bytes_.begin(); }
+
+  iterator end() { return bytes_.end(); }
+
+  reverse_iterator rbegin() { return bytes_.rbegin(); }
+
+  reverse_iterator rend() { return bytes_.rend(); }
+
+  const_iterator cbegin() const { return bytes_.begin(); }
+
+  const_iterator cend() const { return bytes_.end(); }
+
+  const_reverse_iterator crbegin() const { return bytes_.rbegin(); }
+
+  const_reverse_iterator crend() const { return bytes_.rend(); }
+
+  const_iterator begin() const { return bytes_.begin(); }
+
+  const_iterator end() const { return bytes_.end(); }
+
+  const_reverse_iterator rbegin() const { return bytes_.rbegin(); }
+
+  const_reverse_iterator rend() const { return bytes_.rend(); }
 
 private:
-
   // actual data
-  std::vector<unsigned char> _bytes;
-
-  // make the << operator a friend so it can access _bytes
-  friend std::ostream &operator<<(std::ostream &s, const Guid &guid);
+  std::array<uint8_t, 16> bytes_;
 };
 
 // Class that can create new guids. The only reason this exists instead of
@@ -90,8 +131,7 @@ private:
 // function would no longer be cross-platform if we parameterized the android
 // version. Instead, construction of the GuidGenerator may be different on
 // each platform, but the use of newGuid is uniform.
-class GuidGenerator
-{
+class GuidGenerator final {
 public:
 #ifdef GUID_ANDROID
   GuidGenerator(JNIEnv *env);
@@ -110,3 +150,5 @@ private:
   jmethodID _leastSignificantBitsMethod;
 #endif
 };
+
+}

--- a/openunderstand/oudb/models.py
+++ b/openunderstand/oudb/models.py
@@ -52,7 +52,10 @@ class ReferenceModel(Model):
     _scope = ForeignKeyField(EntityModel, backref="inv_refs")
 
     def __str__(self):
-        return f"{self._kind} {self._ent} {self._file}({self._line}, {self._column})"
+        try:
+            return f"{self._kind} {self._ent} {self._file}({self._line}, {self._column})"
+        except:
+            return f"ReferenceModel(id={self._id})"
 
 
 class ProjectModel(Model):


### PR DESCRIPTION
## Description

This PR fixes the `ReferenceModel.__str__()` method to handle cases where foreign keys are not set.

## Related Issue

Fixes: #80  